### PR TITLE
Make stack trace parser API usable.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
 Metrics/LineLength:
   Max: 120
 
+Metrics/ModuleLength:
+  Exclude:
+    - 'spec/**/*_spec.rb'
+
 Metrics/BlockLength:
   Exclude:
     - 'Rakefile'

--- a/bin/tracetool
+++ b/bin/tracetool
@@ -1,2 +1,2 @@
 #!/usr/bin/env ruby
-require_relative '../lib/tracetool'
+require_relative '../lib/tracetool_cli'

--- a/lib/tracetool.rb
+++ b/lib/tracetool.rb
@@ -3,24 +3,5 @@ require 'powerpack/string'
 
 require_relative 'tracetool/android'
 require_relative 'tracetool/ios'
-require_relative 'tracetool/utils/cli'
 require_relative 'tracetool/utils/env'
 require_relative 'tracetool/utils/pipe'
-
-opts = Tracetool::ParseArgs.parse(ARGV)
-case opts.platform
-when :android
-  stack = ARGF.read
-  puts Tracetool::Android.scan(stack,
-                               symbols: opts.sym_dir,
-                               arch: opts.arch.to_s)
-when :ios
-  stack = ARGF.read
-  puts Tracetool::IOS.scan(stack,
-                           arch: opts.arch.to_s,
-                           xarchive: opts.sym_dir,
-                           module_name: opts.modulename,
-                           load_address: opts.address)
-else
-  raise "Unknown(#{opts.platform})"
-end

--- a/lib/tracetool/android.rb
+++ b/lib/tracetool/android.rb
@@ -21,8 +21,10 @@ module Tracetool
 
       # Creates parser for last unpacked trace
       # @param [Array] files list of source files used in build
-      # @return [Tracetool::BaseTraceParser] parser that matches trace format
+      # @return [Tracetool::BaseTraceParser] parser that matches trace format.
+      #   Or `nil`. If there was no scanning.
       def parser(files)
+        return unless @scanner
         @scanner.parser(files)
       end
     end

--- a/lib/tracetool/android.rb
+++ b/lib/tracetool/android.rb
@@ -14,9 +14,16 @@ module Tracetool
       # @param [String] trace trace body
       def process(trace, context)
         # Find scanner which matches trace format
-        scanner = SCANNERS.map { |s| s[trace] }.compact.first
-        raise(ArgumentError, "#{trace}\n not android trace?") unless scanner
-        scanner.process(context)
+        @scanner = SCANNERS.map { |s| s[trace] }.compact.first
+        raise(ArgumentError, "#{trace}\n not android trace?") unless @scanner
+        @scanner.process(context)
+      end
+
+      # Creates parser for last unpacked trace
+      # @param [Array] files list of source files used in build
+      # @return [Tracetool::BaseTraceParser] parser that matches trace format
+      def parser(files)
+        @scanner.parser(files)
       end
     end
 

--- a/lib/tracetool/android/java.rb
+++ b/lib/tracetool/android/java.rb
@@ -26,6 +26,14 @@ module Tracetool
         @trace
       end
 
+      # Create parser for current trace format
+      # @param [Array] files list of files used in build. This files are
+      #   used to match file entries from stack trace to real files
+      # @return [Tracetool::BaseTraceParser] parser that matches trace format
+      def parser(files)
+        JavaTraceParser.new(files)
+      end
+
       class << self
         def match(string)
           # Split into lines

--- a/lib/tracetool/android/native.rb
+++ b/lib/tracetool/android/native.rb
@@ -105,6 +105,14 @@ module Tracetool
         Pipe['ndk-stack', '-sym', symbols] << @trace
       end
 
+      # Create parser for current trace format
+      # @param [Array] files list of files used in build. This files are
+      #   used to match file entries from stack trace to real files
+      # @return [Tracetool::BaseTraceParser] parser that matches trace format
+      def parser(files)
+        NativeTraceParser.new(files)
+      end
+
       class << self
         # Add methods for trace normalization
         include Tracetool::Android::NativeTraceEnhancer

--- a/lib/tracetool/ios/scanner.rb
+++ b/lib/tracetool/ios/scanner.rb
@@ -60,6 +60,14 @@ module Tracetool
         Pipe['atos', *AtosContext.new(context).to_args] << trace
       end
 
+      # Create parser for current trace format
+      # @param [Array] files list of files used in build. This files are
+      #   used to match file entries from stack trace to real files
+      # @return [Tracetool::BaseTraceParser] parser that matches trace format
+      def parser(files)
+        IOSTraceParser.new(files)
+      end
+
       private
 
       def mix(trace, symbolicated)

--- a/lib/tracetool_cli.rb
+++ b/lib/tracetool_cli.rb
@@ -1,0 +1,20 @@
+require_relative 'tracetool'
+require_relative 'tracetool/utils/cli'
+
+opts = Tracetool::ParseArgs.parse(ARGV)
+case opts.platform
+when :android
+  stack = ARGF.read
+  puts Tracetool::Android.scan(stack,
+                               symbols: opts.sym_dir,
+                               arch: opts.arch.to_s)
+when :ios
+  stack = ARGF.read
+  puts Tracetool::IOS.scan(stack,
+                           arch: opts.arch.to_s,
+                           xarchive: opts.sym_dir,
+                           module_name: opts.modulename,
+                           load_address: opts.address)
+else
+  raise "Unknown(#{opts.platform})"
+end

--- a/spec/tracetool/android/java/scanner_spec.rb
+++ b/spec/tracetool/android/java/scanner_spec.rb
@@ -1,8 +1,8 @@
 require_relative lib('tracetool/android/java')
 
-describe Tracetool::Android::JavaTraceScanner do
-  describe '#match' do
-    context 'when example java trace' do
+module Tracetool
+  module Android
+    describe JavaTraceScanner do
       let(:trace) do
         <<-JAVA.strip_indent
         java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
@@ -35,11 +35,21 @@ describe Tracetool::Android::JavaTraceScanner do
           at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1194)
         JAVA
       end
+      describe '#match' do
+        context 'when example java trace' do
+          let(:matcher) { JavaTraceScanner }
 
-      let(:matcher) { Tracetool::Android::JavaTraceScanner }
+          it 'should match java trace' do
+            expect(matcher.match(trace)).to be_truthy
+          end
+        end
+      end
 
-      it 'should match java trace' do
-        expect(matcher.match(trace)).to be_truthy
+      describe '#parser' do
+        it 'creates JavaTraceParser' do
+          expect(JavaTraceScanner.new(trace).parser([]))
+            .to be_a(JavaTraceParser)
+        end
       end
     end
   end

--- a/spec/tracetool/android/native/scanner_spec.rb
+++ b/spec/tracetool/android/native/scanner_spec.rb
@@ -1,265 +1,267 @@
 require_relative lib('tracetool/android/native')
 
-describe Tracetool::Android::NativeTraceScanner do
-  let(:scanner) { Tracetool::Android::NativeTraceScanner }
+module Tracetool
+  module Android
+    describe NativeTraceScanner do
+      describe '::packed?' do
+        context 'when it packed trace' do
+          it 'should not match empty trace (<<<>>>)' do
+            expect(NativeTraceScanner.packed?('<<<>>>')).to be_falsey
+          end
 
-  describe '::packed?' do
-    context 'when it packed trace' do
-      it 'should not match empty trace (<<<>>>)' do
-        expect(scanner.packed?('<<<>>>')).to be_falsey
-      end
+          it 'should match single line trace' do
+            expect(NativeTraceScanner.packed?('<<<12345678 foo.so ;>>>')).to be_truthy
+          end
 
-      it 'should match single line trace' do
-        expect(scanner.packed?('<<<12345678 foo.so ;>>>')).to be_truthy
-      end
+          it 'should match single line trace with symbol' do
+            expect(NativeTraceScanner.packed?('<<<12345678 foo.so __bar 42;>>>')).to be_truthy
+          end
 
-      it 'should match single line trace with symbol' do
-        expect(scanner.packed?('<<<12345678 foo.so __bar 42;>>>')).to be_truthy
-      end
+          it 'should match multi line trace' do
+            expect(NativeTraceScanner.packed?('<<<12345678 foo.so ;12345678 foo.so ;>>>')).to be_truthy
+          end
 
-      it 'should match multi line trace' do
-        expect(scanner.packed?('<<<12345678 foo.so ;12345678 foo.so ;>>>')).to be_truthy
-      end
+          it 'should match multi line trace with symbol' do
+            trace = '<<<12345678 foo.so __bar 42;12345678 foo.so __bar 42;>>>'
+            expect(NativeTraceScanner.packed?(trace)).to be_truthy
+          end
 
-      it 'should match multi line trace with symbol' do
-        trace = '<<<12345678 foo.so __bar 42;12345678 foo.so __bar 42;>>>'
-        expect(scanner.packed?(trace)).to be_truthy
-      end
+          it 'should match multi line trace combined' do
+            trace = '<<<12345678 foo.so ;12345678 foo.so __bar 42;>>>'
+            expect(NativeTraceScanner.packed?(trace)).to be_truthy
+          end
 
-      it 'should match multi line trace combined' do
-        trace = '<<<12345678 foo.so ;12345678 foo.so __bar 42;>>>'
-        expect(scanner.packed?(trace)).to be_truthy
-      end
-
-      it 'should match sequential blocks' do
-        trace = '<<<12345678 foo.so ;12345678 foo.so __bar 42;>>>' \
+          it 'should match sequential blocks' do
+            trace = '<<<12345678 foo.so ;12345678 foo.so __bar 42;>>>' \
               '<<<12345678 foo.so ;12345678 foo.so __bar 42;>>>'
-        expect(scanner.packed?(trace)).to be_truthy
+            expect(NativeTraceScanner.packed?(trace)).to be_truthy
+          end
+        end
+      end
+
+      describe '::without_header?' do
+        context 'when it striped crash' do
+          let(:trace) do
+            <<-TRACE.strip_indent
+            backtrace:
+                native: pc 00000000004321ec  libvizornative.so
+                native: pc 000000000042db8d  libvizornative.so
+                native: pc 0000000000c35865  base.odex
+            TRACE
+          end
+          it do
+            expect(NativeTraceScanner.without_header?(trace)).to be_truthy
+          end
+        end
+
+        context 'when it crash with stack frames' do
+          let(:trace) do
+            <<-TRACE.strip_indent
+            backtrace:
+                #00 pc 00000000004321ec  libvizornative.so
+                #00 pc 000000000042db8d  libvizornative.so
+                #00 pc 0000000000c35865  base.odex
+            TRACE
+          end
+          it do
+            expect(NativeTraceScanner.without_header?(trace)).to be_truthy
+          end
+        end
+      end
+
+      describe '::with_header?' do
+        context 'when it system trace' do
+          let(:trace) do
+            # Example from https://developer.android.com/ndk/guides/ndk-stack.html
+            <<-TRACE.strip_indent
+            I/DEBUG   (   31): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+            I/DEBUG   (   31): Build fingerprint: 'generic/google_sdk/generic/:2.2/FRF91/43546:eng/test-keys'
+            I/DEBUG   (   31): pid: 351, tid: 351  >>> /data/local/ndk-tests/crasher <<<
+            I/DEBUG   (   31): signal 11 (SIGSEGV), fault addr 0d9f00d8
+            I/DEBUG   (   31):  r0 0000af88  r1 0000a008  r2 baadf00d  r3 0d9f00d8
+            I/DEBUG   (   31):  r4 00000004  r5 0000a008  r6 0000af88  r7 00013c44
+            I/DEBUG   (   31):  r8 00000000  r9 00000000  10 00000000  fp 00000000
+            I/DEBUG   (   31):  ip 0000959c  sp be956cc8  lr 00008403  pc 0000841e  cpsr 60000030
+            I/DEBUG   (   31):          #00  pc 0000841e  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #01  pc 000083fe  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #02  pc 000083f6  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #03  pc 000191ac  /system/lib/libc.so
+            I/DEBUG   (   31):          #04  pc 000083ea  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #05  pc 00008458  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #06  pc 0000d362  /system/lib/libc.so
+            I/DEBUG   (   31):
+            TRACE
+          end
+
+          it do
+            expect(NativeTraceScanner.with_header?(trace)).to be_truthy
+          end
+        end
+
+        context 'when it clean crash report' do
+          let(:trace) do
+            <<-TRACE.strip_indent
+            *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+            Build fingerprint: 'generic/google_sdk/generic/:2.2/FRF91/43546:eng/test-keys'
+            pid: 351, tid: 351  >>> /data/local/ndk-tests/crasher <<<
+            signal 11 (SIGSEGV), fault addr 0d9f00d8
+             r0 0000af88  r1 0000a008  r2 baadf00d  r3 0d9f00d8
+             r4 00000004  r5 0000a008  r6 0000af88  r7 00013c44
+             r8 00000000  r9 00000000  10 00000000  fp 00000000
+             ip 0000959c  sp be956cc8  lr 00008403  pc 0000841e  cpsr 60000030
+            backtrace:
+                native: pc 00000000004321ec  libvizornative.so
+                native: pc 000000000042db8d  libvizornative.so
+                native: pc 0000000000c35865  base.odex
+            TRACE
+          end
+          it 'should match' do
+            expect(NativeTraceScanner.with_header?(trace)).to be_truthy
+          end
+        end
+      end
+
+      describe '#process' do
+        skip_ndk_stack = if Tracetool::Env.which('ndk-stack')
+                           false
+                         else
+                           'No ndk-stack found'
+                         end
+
+        let(:trace) do
+          <<-TRACE.strip_indent
+          *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+          Build fingerprint: UNKNOWN
+          pid: 0, tid: 0
+          signal 0 (UNKNOWN)
+          backtrace:
+                   #00  pc 0000841e  /data/local/ndk-tests/crasher
+                   #01  pc 000083fe  /data/local/ndk-tests/crasher
+                   #02  pc 000083f6  /data/local/ndk-tests/crasher
+                   #03  pc 000191ac  /system/lib/libc.so
+                   #04  pc 000083ea  /data/local/ndk-tests/crasher
+                   #05  pc 00008458  /data/local/ndk-tests/crasher
+                   #06  pc 0000d362  /system/lib/libc.so
+          TRACE
+        end
+
+        it 'pipes stack trace through ndk-stack', skip: skip_ndk_stack do
+          expect = <<-TRACE.strip_indent.chomp
+          ********** Crash dump: **********
+          Build fingerprint: UNKNOWN
+          pid: 0, tid: 0
+          signal 0 (UNKNOWN)
+          Stack frame #00  pc 0000841e  /data/local/ndk-tests/crasher
+          Stack frame #01  pc 000083fe  /data/local/ndk-tests/crasher
+          Stack frame #02  pc 000083f6  /data/local/ndk-tests/crasher
+          Stack frame #03  pc 000191ac  /system/lib/libc.so
+          Stack frame #04  pc 000083ea  /data/local/ndk-tests/crasher
+          Stack frame #05  pc 00008458  /data/local/ndk-tests/crasher
+          Stack frame #06  pc 0000d362  /system/lib/libc.so
+          TRACE
+
+          Dir.mktmpdir do |dir|
+            ctx = OpenStruct.new(symbols: dir)
+            expect(NativeTraceScanner.new(trace).process(ctx)).to eq(expect)
+          end
+        end
+
+        context 'when context has arch and symbols' do
+          let(:exec) { double }
+          before do
+            expect(Tracetool::Pipe::Executor)
+              .to receive(:new)
+              .with('ndk-stack', %w[-sym /tmp/symbols/local/arch])
+              .and_return(exec)
+            allow(exec).to receive(:<<).and_return('native')
+          end
+
+          it do
+            ctx = OpenStruct.new(symbols: '/tmp/symbols', arch: 'arch')
+            expect(NativeTraceScanner.new(trace).process(ctx)).to eq('native')
+          end
+        end
+
+        context 'when context has only symbols' do
+          let(:exec) { double }
+          before do
+            @tmp_dir = Dir.mktmpdir
+            FileUtils.mkdir_p(File.join(@tmp_dir, 'local/arch'))
+            expect(Tracetool::Pipe::Executor)
+              .to receive(:new)
+              .with('ndk-stack', ['-sym', File.join(@tmp_dir, 'local/arch')])
+              .and_return(exec)
+            allow(exec).to receive(:<<).and_return('native')
+          end
+
+          it do
+            ctx = OpenStruct.new(symbols: @tmp_dir)
+            expect(NativeTraceScanner.new(trace).process(ctx)).to eq('native')
+          end
+
+          after do
+            FileUtils.remove_entry @tmp_dir
+          end
+        end
       end
     end
-  end
 
-  describe '::without_header?' do
-    context 'when it striped crash' do
-      let(:trace) do
-        <<-TRACE.strip_indent
-        backtrace:
-            native: pc 00000000004321ec  libvizornative.so
-            native: pc 000000000042db8d  libvizornative.so
-            native: pc 0000000000c35865  base.odex
-        TRACE
+    describe NativeTraceEnhancer do
+      let(:enhancer) do
+        Class.new { extend NativeTraceEnhancer }
       end
-      it do
-        expect(scanner.without_header?(trace)).to be_truthy
-      end
-    end
+      describe '#unpack' do
+        it 'should convert packed trace to ndk trace' do
+          unpacked = <<-NDK.strip_indent.chomp
+          *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+          Build fingerprint: UNKNOWN
+          pid: 0, tid: 0
+          signal 0 (UNKNOWN)
+          backtrace:
+              #00  pc 000004d2  lib.so
+          NDK
+          expect(enhancer.unpack('<<<1234 lib.so ;>>>')).to eq(unpacked)
+        end
 
-    context 'when it crash with stack frames' do
-      let(:trace) do
-        <<-TRACE.strip_indent
-        backtrace:
-            #00 pc 00000000004321ec  libvizornative.so
-            #00 pc 000000000042db8d  libvizornative.so
-            #00 pc 0000000000c35865  base.odex
-        TRACE
-      end
-      it do
-        expect(scanner.without_header?(trace)).to be_truthy
-      end
-    end
-  end
+        it 'should keep symbol and offset' do
+          original = '<<<1234 lib.so _foo 42;>>>'
+          unpacked = <<-NDK.strip_indent.chomp
+          *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+          Build fingerprint: UNKNOWN
+          pid: 0, tid: 0
+          signal 0 (UNKNOWN)
+          backtrace:
+              #00  pc 000004d2  lib.so _foo 42
+          NDK
+          expect(enhancer.unpack(original)).to eq(unpacked)
+        end
 
-  describe '::with_header?' do
-    context 'when it system trace' do
-      let(:trace) do
-        # Example from https://developer.android.com/ndk/guides/ndk-stack.html
-        <<-TRACE.strip_indent
-        I/DEBUG   (   31): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-        I/DEBUG   (   31): Build fingerprint: 'generic/google_sdk/generic/:2.2/FRF91/43546:eng/test-keys'
-        I/DEBUG   (   31): pid: 351, tid: 351  >>> /data/local/ndk-tests/crasher <<<
-        I/DEBUG   (   31): signal 11 (SIGSEGV), fault addr 0d9f00d8
-        I/DEBUG   (   31):  r0 0000af88  r1 0000a008  r2 baadf00d  r3 0d9f00d8
-        I/DEBUG   (   31):  r4 00000004  r5 0000a008  r6 0000af88  r7 00013c44
-        I/DEBUG   (   31):  r8 00000000  r9 00000000  10 00000000  fp 00000000
-        I/DEBUG   (   31):  ip 0000959c  sp be956cc8  lr 00008403  pc 0000841e  cpsr 60000030
-        I/DEBUG   (   31):          #00  pc 0000841e  /data/local/ndk-tests/crasher
-        I/DEBUG   (   31):          #01  pc 000083fe  /data/local/ndk-tests/crasher
-        I/DEBUG   (   31):          #02  pc 000083f6  /data/local/ndk-tests/crasher
-        I/DEBUG   (   31):          #03  pc 000191ac  /system/lib/libc.so
-        I/DEBUG   (   31):          #04  pc 000083ea  /data/local/ndk-tests/crasher
-        I/DEBUG   (   31):          #05  pc 00008458  /data/local/ndk-tests/crasher
-        I/DEBUG   (   31):          #06  pc 0000d362  /system/lib/libc.so
-        I/DEBUG   (   31):
-        TRACE
+        it 'should convert multiline traces correctly' do
+          original = '<<<1234 lib.so ;1234 lib.so ;1234 lib.so ;12345678 lib.so _foo 42;1234 lib.so ;>>>'
+          unpacked = <<-NDK.strip_indent.chomp
+          *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+          Build fingerprint: UNKNOWN
+          pid: 0, tid: 0
+          signal 0 (UNKNOWN)
+          backtrace:
+              #00  pc 000004d2  lib.so
+              #01  pc 000004d2  lib.so
+              #02  pc 000004d2  lib.so
+              #03  pc 00bc614e  lib.so _foo 42
+              #04  pc 000004d2  lib.so
+          NDK
+          expect(enhancer.unpack(original)).to eq(unpacked)
+        end
       end
 
-      it do
-        expect(scanner.with_header?(trace)).to be_truthy
+      describe '#add_header' do
+        let(:dummy_header) do
+          NativeTraceEnhancer::NATIVE_DUMP_HEADER
+        end
+        it 'adds dummy header' do
+          expect(enhancer.add_header('')).to eq(dummy_header)
+        end
       end
-    end
-
-    context 'when it clean crash report' do
-      let(:trace) do
-        <<-TRACE.strip_indent
-        *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-        Build fingerprint: 'generic/google_sdk/generic/:2.2/FRF91/43546:eng/test-keys'
-        pid: 351, tid: 351  >>> /data/local/ndk-tests/crasher <<<
-        signal 11 (SIGSEGV), fault addr 0d9f00d8
-         r0 0000af88  r1 0000a008  r2 baadf00d  r3 0d9f00d8
-         r4 00000004  r5 0000a008  r6 0000af88  r7 00013c44
-         r8 00000000  r9 00000000  10 00000000  fp 00000000
-         ip 0000959c  sp be956cc8  lr 00008403  pc 0000841e  cpsr 60000030
-        backtrace:
-            native: pc 00000000004321ec  libvizornative.so
-            native: pc 000000000042db8d  libvizornative.so
-            native: pc 0000000000c35865  base.odex
-        TRACE
-      end
-      it 'should match' do
-        expect(scanner.with_header?(trace)).to be_truthy
-      end
-    end
-  end
-
-  describe '#process' do
-    skip_ndk_stack = if Tracetool::Env.which('ndk-stack')
-                       false
-                     else
-                       'No ndk-stack found'
-                     end
-
-    let(:trace) do
-      <<-TRACE.strip_indent
-      *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-      Build fingerprint: UNKNOWN
-      pid: 0, tid: 0
-      signal 0 (UNKNOWN)
-      backtrace:
-               #00  pc 0000841e  /data/local/ndk-tests/crasher
-               #01  pc 000083fe  /data/local/ndk-tests/crasher
-               #02  pc 000083f6  /data/local/ndk-tests/crasher
-               #03  pc 000191ac  /system/lib/libc.so
-               #04  pc 000083ea  /data/local/ndk-tests/crasher
-               #05  pc 00008458  /data/local/ndk-tests/crasher
-               #06  pc 0000d362  /system/lib/libc.so
-      TRACE
-    end
-
-    it 'pipes stack trace through ndk-stack', skip: skip_ndk_stack do
-      expect = <<-TRACE.strip_indent.chomp
-      ********** Crash dump: **********
-      Build fingerprint: UNKNOWN
-      pid: 0, tid: 0
-      signal 0 (UNKNOWN)
-      Stack frame #00  pc 0000841e  /data/local/ndk-tests/crasher
-      Stack frame #01  pc 000083fe  /data/local/ndk-tests/crasher
-      Stack frame #02  pc 000083f6  /data/local/ndk-tests/crasher
-      Stack frame #03  pc 000191ac  /system/lib/libc.so
-      Stack frame #04  pc 000083ea  /data/local/ndk-tests/crasher
-      Stack frame #05  pc 00008458  /data/local/ndk-tests/crasher
-      Stack frame #06  pc 0000d362  /system/lib/libc.so
-      TRACE
-
-      Dir.mktmpdir do |dir|
-        ctx = OpenStruct.new(symbols: dir)
-        expect(scanner.new(trace).process(ctx)).to eq(expect)
-      end
-    end
-
-    context 'when context has arch and symbols' do
-      let(:exec) { double }
-      before do
-        expect(Tracetool::Pipe::Executor)
-          .to receive(:new)
-          .with('ndk-stack', %w[-sym /tmp/symbols/local/arch])
-          .and_return(exec)
-        allow(exec).to receive(:<<).and_return('native')
-      end
-
-      it do
-        ctx = OpenStruct.new(symbols: '/tmp/symbols', arch: 'arch')
-        expect(scanner.new(trace).process(ctx)).to eq('native')
-      end
-    end
-
-    context 'when context has only symbols' do
-      let(:exec) { double }
-      before do
-        @tmp_dir = Dir.mktmpdir
-        FileUtils.mkdir_p(File.join(@tmp_dir, 'local/arch'))
-        expect(Tracetool::Pipe::Executor)
-          .to receive(:new)
-          .with('ndk-stack', ['-sym', File.join(@tmp_dir, 'local/arch')])
-          .and_return(exec)
-        allow(exec).to receive(:<<).and_return('native')
-      end
-
-      it do
-        ctx = OpenStruct.new(symbols: @tmp_dir)
-        expect(scanner.new(trace).process(ctx)).to eq('native')
-      end
-
-      after do
-        FileUtils.remove_entry @tmp_dir
-      end
-    end
-  end
-end
-
-describe Tracetool::Android::NativeTraceEnhancer do
-  let(:enhancer) do
-    Class.new { extend Tracetool::Android::NativeTraceEnhancer }
-  end
-  describe '#unpack' do
-    it 'should convert packed trace to ndk trace' do
-      unpacked = <<-NDK.strip_indent.chomp
-      *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-      Build fingerprint: UNKNOWN
-      pid: 0, tid: 0
-      signal 0 (UNKNOWN)
-      backtrace:
-          #00  pc 000004d2  lib.so
-      NDK
-      expect(enhancer.unpack('<<<1234 lib.so ;>>>')).to eq(unpacked)
-    end
-
-    it 'should keep symbol and offset' do
-      original = '<<<1234 lib.so _foo 42;>>>'
-      unpacked = <<-NDK.strip_indent.chomp
-      *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-      Build fingerprint: UNKNOWN
-      pid: 0, tid: 0
-      signal 0 (UNKNOWN)
-      backtrace:
-          #00  pc 000004d2  lib.so _foo 42
-      NDK
-      expect(enhancer.unpack(original)).to eq(unpacked)
-    end
-
-    it 'should convert multiline traces correctly' do
-      original = '<<<1234 lib.so ;1234 lib.so ;1234 lib.so ;12345678 lib.so _foo 42;1234 lib.so ;>>>'
-      unpacked = <<-NDK.strip_indent.chomp
-      *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-      Build fingerprint: UNKNOWN
-      pid: 0, tid: 0
-      signal 0 (UNKNOWN)
-      backtrace:
-          #00  pc 000004d2  lib.so
-          #01  pc 000004d2  lib.so
-          #02  pc 000004d2  lib.so
-          #03  pc 00bc614e  lib.so _foo 42
-          #04  pc 000004d2  lib.so
-      NDK
-      expect(enhancer.unpack(original)).to eq(unpacked)
-    end
-  end
-
-  describe '#add_header' do
-    let(:dummy_header) do
-      Tracetool::Android::NativeTraceEnhancer::NATIVE_DUMP_HEADER
-    end
-    it 'adds dummy header' do
-      expect(enhancer.add_header('')).to eq(dummy_header)
     end
   end
 end

--- a/spec/tracetool/android_spec.rb
+++ b/spec/tracetool/android_spec.rb
@@ -1,92 +1,149 @@
 require_relative lib('tracetool/android')
 
-describe Tracetool::Android::AndroidTraceScanner do
-  let(:scanner) { Tracetool::Android }
+module Tracetool
+  describe Android do
+    describe '::scan' do
+      context('when it not a trace') do
+        it 'raises ArgumentError' do
+          expect { Android.scan('NOT A TRACE', {}) }
+            .to raise_error(ArgumentError)
+        end
+      end
 
-  describe '#process' do
-    context('when it not a trace') do
-      it 'raises ArgumentError' do
-        expect { scanner.scan('NOT A TRACE', {}) }
-          .to raise_error(ArgumentError)
+      context('when it java trace') do
+        let(:trace) do
+          <<-JAVA.strip_indent
+            java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
+              at java.lang.Thread.nativeCreate(Native Method)
+              at java.lang.Thread.start(Thread.java:1063)
+              at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:920)
+              at java.util.concurrent.ThreadPoolExecutor.ensurePrestart(ThreadPoolExecutor.java:1553)
+            JAVA
+        end
+
+        let(:ctx) { OpenStruct.new }
+        it 'should unpack java' do
+          expect(Android.scan(trace, ctx)).to eq(trace)
+        end
+      end
+
+      context('when it native trace') do
+        context('when it logcat trace') do
+          let(:trace) do
+            <<-LOGCAT.strip_indent
+            I/DEBUG   (   31): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
+            I/DEBUG   (   31): Build fingerprint: 'generic/google_sdk/generic/:2.2/FRF91/43546:eng/test-keys'
+            I/DEBUG   (   31): pid: 351, tid: 351  >>> /data/local/ndk-tests/crasher <<<
+            I/DEBUG   (   31): signal 11 (SIGSEGV), fault addr 0d9f00d8
+            I/DEBUG   (   31):  r0 0000af88  r1 0000a008  r2 baadf00d  r3 0d9f00d8
+            I/DEBUG   (   31):  r4 00000004  r5 0000a008  r6 0000af88  r7 00013c44
+            I/DEBUG   (   31):  r8 00000000  r9 00000000  10 00000000  fp 00000000
+            I/DEBUG   (   31):  ip 0000959c  sp be956cc8  lr 00008403  pc 0000841e  cpsr 60000030
+            I/DEBUG   (   31):          #00  pc 0000841e  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #01  pc 000083fe  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #02  pc 000083f6  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #03  pc 000191ac  /system/lib/libc.so
+            I/DEBUG   (   31):          #04  pc 000083ea  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #05  pc 00008458  /data/local/ndk-tests/crasher
+            I/DEBUG   (   31):          #06  pc 0000d362  /system/lib/libc.so
+            I/DEBUG   (   31):
+            LOGCAT
+          end
+          it 'should process native trace' do
+            exec = Tracetool::Pipe::Executor.new('cmd')
+            allow(exec).to receive(:<<).and_return('native')
+            allow(Tracetool::Pipe).to receive(:[]).and_return(exec)
+
+            expect(Android.scan(trace, symbols: '/tmp'))
+              .to eq('native')
+          end
+        end
+
+        context('when it striped trace') do
+          let(:trace) do
+            <<-TRACE.strip_indent
+            backtrace:
+                native: pc 00000000004321ec  libvizornative.so
+                native: pc 000000000042db8d  libvizornative.so
+                native: pc 0000000000c35865  base.odex
+            TRACE
+          end
+          it 'should process native trace' do
+            exec = Tracetool::Pipe::Executor.new('cmd')
+            allow(exec).to receive(:<<).and_return('native')
+            allow(Tracetool::Pipe).to receive(:[]).and_return(exec)
+
+            expect(Android.scan(trace, symbols: '/tmp'))
+              .to eq('native')
+          end
+        end
+
+        context('when it clean trace') do
+          it 'should process native trace' do
+            exec = Tracetool::Pipe::Executor.new('cmd')
+            allow(exec).to receive(:<<).and_return('native')
+            allow(Tracetool::Pipe).to receive(:[]).and_return(exec)
+
+            expect(Android.scan('<<<123456 foo.so ;>>>', symbols: '/tmp'))
+              .to eq('native')
+          end
+        end
       end
     end
+  end
 
-    context('when it java trace') do
-      let(:trace) do
-        <<-JAVA.strip_indent
-        java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
-          at java.lang.Thread.nativeCreate(Native Method)
-          at java.lang.Thread.start(Thread.java:1063)
-          at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:920)
-          at java.util.concurrent.ThreadPoolExecutor.ensurePrestart(ThreadPoolExecutor.java:1553)
-        JAVA
-      end
-
-      let(:ctx) { OpenStruct.new }
-      it 'should unpack java' do
-        expect(scanner.scan(trace, ctx)).to eq(trace)
-      end
-    end
-
-    context('when it native trace') do
-      context('when it logcat trace') do
-        let(:trace) do
-          <<-LOGCAT.strip_indent
-          I/DEBUG   (   31): *** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
-          I/DEBUG   (   31): Build fingerprint: 'generic/google_sdk/generic/:2.2/FRF91/43546:eng/test-keys'
-          I/DEBUG   (   31): pid: 351, tid: 351  >>> /data/local/ndk-tests/crasher <<<
-          I/DEBUG   (   31): signal 11 (SIGSEGV), fault addr 0d9f00d8
-          I/DEBUG   (   31):  r0 0000af88  r1 0000a008  r2 baadf00d  r3 0d9f00d8
-          I/DEBUG   (   31):  r4 00000004  r5 0000a008  r6 0000af88  r7 00013c44
-          I/DEBUG   (   31):  r8 00000000  r9 00000000  10 00000000  fp 00000000
-          I/DEBUG   (   31):  ip 0000959c  sp be956cc8  lr 00008403  pc 0000841e  cpsr 60000030
-          I/DEBUG   (   31):          #00  pc 0000841e  /data/local/ndk-tests/crasher
-          I/DEBUG   (   31):          #01  pc 000083fe  /data/local/ndk-tests/crasher
-          I/DEBUG   (   31):          #02  pc 000083f6  /data/local/ndk-tests/crasher
-          I/DEBUG   (   31):          #03  pc 000191ac  /system/lib/libc.so
-          I/DEBUG   (   31):          #04  pc 000083ea  /data/local/ndk-tests/crasher
-          I/DEBUG   (   31):          #05  pc 00008458  /data/local/ndk-tests/crasher
-          I/DEBUG   (   31):          #06  pc 0000d362  /system/lib/libc.so
-          I/DEBUG   (   31):
-          LOGCAT
+  module Android
+    describe AndroidTraceScanner do
+      describe '#parser' do
+        context 'when was no trace' do
+          it do
+            expect(AndroidTraceScanner.new.parser([])).to be(nil)
+          end
         end
-        it 'should process native trace' do
-          exec = Tracetool::Pipe::Executor.new('cmd')
-          allow(exec).to receive(:<<).and_return('native')
-          allow(Tracetool::Pipe).to receive(:[]).and_return(exec)
 
-          expect(scanner.scan(trace, symbols: '/tmp'))
-            .to eq('native')
+        context 'when was java trace' do
+          let(:trace) do
+            <<-JAVA.strip_indent
+            java.lang.OutOfMemoryError: pthread_create (1040KB stack) failed: Try again
+              at java.lang.Thread.nativeCreate(Native Method)
+              at java.lang.Thread.start(Thread.java:1063)
+              at java.util.concurrent.ThreadPoolExecutor.addWorker(ThreadPoolExecutor.java:920)
+              at java.util.concurrent.ThreadPoolExecutor.ensurePrestart(ThreadPoolExecutor.java:1553)
+            JAVA
+          end
+
+          it 'creates parser from JavaTraceScanner' do
+            scanner = AndroidTraceScanner.new
+            mocked_scanner = double
+            expect(JavaTraceScanner).to receive(:new).and_return(mocked_scanner)
+            expect(mocked_scanner).to receive(:process).and_return(nil)
+            scanner.process(trace, OpenStruct.new)
+            expect(mocked_scanner)
+              .to receive(:parser).with([]).and_return(JavaTraceParser.new([]))
+            expect(scanner.parser([])).to be_a(JavaTraceParser)
+          end
         end
-      end
 
-      context('when it striped trace') do
-        let(:trace) do
-          <<-TRACE.strip_indent
-          backtrace:
-              native: pc 00000000004321ec  libvizornative.so
-              native: pc 000000000042db8d  libvizornative.so
-              native: pc 0000000000c35865  base.odex
-          TRACE
-        end
-        it 'should process native trace' do
-          exec = Tracetool::Pipe::Executor.new('cmd')
-          allow(exec).to receive(:<<).and_return('native')
-          allow(Tracetool::Pipe).to receive(:[]).and_return(exec)
+        context 'when was native trace' do
+          let(:trace) do
+            <<-TRACE.strip_indent
+            backtrace:
+                native: pc 00000000004321ec  libvizornative.so
+                native: pc 000000000042db8d  libvizornative.so
+                native: pc 0000000000c35865  base.odex
+            TRACE
+          end
 
-          expect(scanner.scan(trace, symbols: '/tmp'))
-            .to eq('native')
-        end
-      end
-
-      context('when it clean trace') do
-        it 'should process native trace' do
-          exec = Tracetool::Pipe::Executor.new('cmd')
-          allow(exec).to receive(:<<).and_return('native')
-          allow(Tracetool::Pipe).to receive(:[]).and_return(exec)
-
-          expect(scanner.scan('<<<123456 foo.so ;>>>', symbols: '/tmp'))
-            .to eq('native')
+          it 'creates parser from NativeTraceScanner' do
+            scanner = AndroidTraceScanner.new
+            mocked_scanner = double
+            expect(NativeTraceScanner).to receive(:new).and_return(mocked_scanner)
+            expect(mocked_scanner).to receive(:process).and_return(nil)
+            scanner.process(trace, OpenStruct.new)
+            expect(mocked_scanner)
+              .to receive(:parser).with([]).and_return(NativeTraceParser.new([]))
+            expect(scanner.parser([])).to be_a(NativeTraceParser)
+          end
         end
       end
     end

--- a/spec/tracetool/ios/scanner_spec.rb
+++ b/spec/tracetool/ios/scanner_spec.rb
@@ -1,6 +1,6 @@
 require_relative lib('tracetool/ios/scanner')
 describe Tracetool::IOS::IOSTraceScanner do
-  let(:parser) { Tracetool::IOS::IOSTraceScanner.new }
+  let(:scaner) { Tracetool::IOS::IOSTraceScanner.new }
 
   let(:trace) do
     <<-IOS_TRACE
@@ -40,7 +40,7 @@ describe Tracetool::IOS::IOSTraceScanner do
     EXPECT
   end
   it 'converts packed trace to atos compatible format' do
-    expect(parser.parse(trace)).to match_array(expected)
+    expect(scaner.parse(trace)).to match_array(expected)
   end
 end
 

--- a/spec/tracetool/ios/scanner_spec.rb
+++ b/spec/tracetool/ios/scanner_spec.rb
@@ -1,148 +1,154 @@
-require_relative lib('tracetool/ios/scanner')
-describe Tracetool::IOS::IOSTraceScanner do
-  let(:scaner) { Tracetool::IOS::IOSTraceScanner.new }
+require_relative lib('tracetool/ios')
 
-  let(:trace) do
-    <<-IOS_TRACE
-    0  Foo                                 0x00000001029b2d48 Foo + 159048
-    1  Foo                                 0x00000001029b37d0 Foo + 161744
-    2  libsystem_platform.dylib            0x00000001857dbb44 _sigtramp + 52
-    3  Foo                                 0x0000000102cf6178 Foo + 3580280
-    4  Foo                                 0x0000000102cc36c0 Foo + 3372736
-    5  UIKit                               0x000000018efc4078 <redacted> + 340
-    6  UIKit                               0x000000018f903f98 <redacted> + 2364
-    7  CoreFoundation                      0x0000000185b5c358 <redacted> + 24
-    8  CoreFoundation                      0x0000000185b5c2d8 <redacted> + 88
-    9  CoreFoundation                      0x0000000185a7a2d8 CFRunLoopRunSpecific + 436
-    10  GraphicsServices                    0x000000018790bf84 GSEventRunModal + 100
-    11  UIKit                               0x000000018f027880 UIApplicationMain + 208
-    12  Foo                                 0x0000000102995c08 Foo + 39944
-    13  libdyld.dylib                       0x000000018559e56c <redacted> + 4
-    IOS_TRACE
-  end
+module Tracetool
+  module IOS
+    describe IOSTraceScanner do
+      describe '#parse' do
+        let(:trace) do
+          <<-IOS_TRACE
+          0  Foo                                 0x00000001029b2d48 Foo + 159048
+          1  Foo                                 0x00000001029b37d0 Foo + 161744
+          2  libsystem_platform.dylib            0x00000001857dbb44 _sigtramp + 52
+          3  Foo                                 0x0000000102cf6178 Foo + 3580280
+          4  Foo                                 0x0000000102cc36c0 Foo + 3372736
+          5  UIKit                               0x000000018efc4078 <redacted> + 340
+          6  UIKit                               0x000000018f903f98 <redacted> + 2364
+          7  CoreFoundation                      0x0000000185b5c358 <redacted> + 24
+          8  CoreFoundation                      0x0000000185b5c2d8 <redacted> + 88
+          9  CoreFoundation                      0x0000000185a7a2d8 CFRunLoopRunSpecific + 436
+          10  GraphicsServices                    0x000000018790bf84 GSEventRunModal + 100
+          11  UIKit                               0x000000018f027880 UIApplicationMain + 208
+          12  Foo                                 0x0000000102995c08 Foo + 39944
+          13  libdyld.dylib                       0x000000018559e56c <redacted> + 4
+          IOS_TRACE
+        end
 
-  let(:expected) do
-    <<-EXPECT.strip_indent.split("\n").map { |l| l.split(' ') }
-    Foo 0x00000001029b2d48
-    Foo 0x00000001029b37d0
-    libsystem_platform.dylib 0x00000001857dbb44
-    Foo 0x0000000102cf6178
-    Foo 0x0000000102cc36c0
-    UIKit 0x000000018efc4078
-    UIKit 0x000000018f903f98
-    CoreFoundation 0x0000000185b5c358
-    CoreFoundation 0x0000000185b5c2d8
-    CoreFoundation 0x0000000185a7a2d8
-    GraphicsServices 0x000000018790bf84
-    UIKit 0x000000018f027880
-    Foo 0x0000000102995c08
-    libdyld.dylib 0x000000018559e56c
-    EXPECT
-  end
-  it 'converts packed trace to atos compatible format' do
-    expect(scaner.parse(trace)).to match_array(expected)
-  end
-end
+        let(:expected) do
+          <<-EXPECT.strip_indent.split("\n").map { |l| l.split(' ') }
+          Foo 0x00000001029b2d48
+          Foo 0x00000001029b37d0
+          libsystem_platform.dylib 0x00000001857dbb44
+          Foo 0x0000000102cf6178
+          Foo 0x0000000102cc36c0
+          UIKit 0x000000018efc4078
+          UIKit 0x000000018f903f98
+          CoreFoundation 0x0000000185b5c358
+          CoreFoundation 0x0000000185b5c2d8
+          CoreFoundation 0x0000000185a7a2d8
+          GraphicsServices 0x000000018790bf84
+          UIKit 0x000000018f027880
+          Foo 0x0000000102995c08
+          libdyld.dylib 0x000000018559e56c
+          EXPECT
+        end
 
-describe Tracetool::IOS::AtosContext do
-  let(:ctx) do
-    c = OpenStruct.new(
-      module_name: 'Foo',
-      xarchive: '/tmp/Foo.xarchive',
-      load_address: '0x0',
-      arch: 'x86_64'
-    )
-    Tracetool::IOS::AtosContext.new(c)
-  end
+        it 'converts packed trace to atos compatible format' do
+          expect(IOSTraceScanner.new.parse(trace)).to match_array(expected)
+        end
+      end
 
-  describe '#to_args' do
-    it 'converts context to command arguments' do
-      expect(ctx.to_args).to match_array(%w[
-                                           -o /tmp/Foo.xarchive/dSYMs/Foo.app.dSYM/Contents/Resources/DWARF/Foo
-                                           -l 0x0
-                                           -arch x86_64
-                                         ])
-    end
-  end
+      describe '#process' do
+        context do
+          let(:launcher) do
+            launcher = IOSTraceScanner.new
+            example_output = <<-OUTPUT.strip_indent
+            some::cpp::namespace::CppClass::method(int, int, void*) (in FooModule) (CppClass.cpp:98)
+            -[FooViewController touchesEnded:withEvent:] (in FooModule) (FooViewController.mm:314)
+            0X000000018559e56c
+            OUTPUT
+            allow(launcher).to receive(:run_atos).and_return example_output
+            launcher
+          end
 
-  describe '#initialize' do
-    %i[load_address xarchive module_name]
-      .each_with_object(load_address: '0x0', xarchive: 'test', module_name: 'Foo') do |argument, object|
-      context "when #{argument} missing" do
-        let(:ctx) { OpenStruct.new(object.dup.update(argument => nil)) }
-        it 'raises exception' do
-          expect { Tracetool::IOS::AtosContext.new(ctx) }.to raise_error(ArgumentError)
+          let(:ctx) do
+            OpenStruct.new(
+              load_address: '0x0',
+              xarchive: 'tmp',
+              module_name: 'FooModule'
+            )
+          end
+
+          it 'should unpack trace' do
+            input = <<-INPUT.strip_indent.chomp
+            0  FooModule                           0x00000001029b37d0 FooModule + 159048
+            1  FooModule                           0x00000001029b2d48 FooModule + 161744
+            2  UIKit                               0x000000018559e56c _sigtramp + 52
+            INPUT
+            ex = <<-EXPECTED.strip_indent.chomp
+            0 FooModule some::cpp::namespace::CppClass::method(int, int, void*) (in FooModule) (CppClass.cpp:98)
+            1 FooModule -[FooViewController touchesEnded:withEvent:] (in FooModule) (FooViewController.mm:314)
+            2 UIKit 0X000000018559e56c
+            EXPECTED
+            expect(launcher.process(input, ctx)).to eq(ex)
+          end
+        end
+
+        context 'when has valid context' do
+          let(:ctx) do
+            OpenStruct.new(
+              load_address: '0x0',
+              xarchive: 'tmp',
+              module_name: 'FooModule'
+            )
+          end
+
+          let(:exec) { double }
+
+          before do
+            atos_args =
+              %w[-o tmp/dSYMs/FooModule.app.dSYM/Contents/Resources/DWARF/FooModule -l 0x0 -arch arm64]
+            expect(Tracetool::Pipe::Executor)
+              .to receive(:new)
+              .with('atos', atos_args)
+              .and_return(exec)
+            expect(exec).to receive(:<<).and_return('foo')
+          end
+
+          it 'runs atos with arguments' do
+            expect(IOSTraceScanner.new.process('0 FooModule 0x0', ctx))
+              .to eq('0 FooModule foo')
+          end
+        end
+      end
+
+      describe '#parser' do
+        it 'returns IOSTraceParser' do
+          expect(IOSTraceScanner.new.parser([])).to be_a(IOSTraceParser)
         end
       end
     end
-  end
-end
 
-describe Tracetool::IOS::IOSTraceScanner do
-  describe '#process' do
-    context do
-      let(:launcher) do
-        launcher = Tracetool::IOS::IOSTraceScanner.new
-        example_output = <<-OUTPUT.strip_indent
-        some::cpp::namespace::CppClass::method(int, int, void*) (in FooModule) (CppClass.cpp:98)
-        -[FooViewController touchesEnded:withEvent:] (in FooModule) (FooViewController.mm:314)
-        0X000000018559e56c
-        OUTPUT
-        allow(launcher).to receive(:run_atos).and_return example_output
-        launcher
-      end
-
+    describe AtosContext do
       let(:ctx) do
-        OpenStruct.new(
+        c = OpenStruct.new(
+          module_name: 'Foo',
+          xarchive: '/tmp/Foo.xarchive',
           load_address: '0x0',
-          xarchive: 'tmp',
-          module_name: 'FooModule'
+          arch: 'x86_64'
         )
+        AtosContext.new(c)
       end
 
-      it 'should unpack trace' do
-        input = <<-INPUT.strip_indent.chomp
-        0  FooModule                           0x00000001029b37d0 FooModule + 159048
-        1  FooModule                           0x00000001029b2d48 FooModule + 161744
-        2  UIKit                               0x000000018559e56c _sigtramp + 52
-        INPUT
-        ex = <<-EXPECTED.strip_indent.chomp
-        0 FooModule some::cpp::namespace::CppClass::method(int, int, void*) (in FooModule) (CppClass.cpp:98)
-        1 FooModule -[FooViewController touchesEnded:withEvent:] (in FooModule) (FooViewController.mm:314)
-        2 UIKit 0X000000018559e56c
-        EXPECTED
-        expect(launcher.process(input, ctx)).to eq(ex)
-      end
-    end
-
-    context 'when has valid context' do
-      let(:ctx) do
-        OpenStruct.new(
-          load_address: '0x0',
-          xarchive: 'tmp',
-          module_name: 'FooModule'
-        )
+      describe '#to_args' do
+        it 'converts context to command arguments' do
+          expect(ctx.to_args).to match_array(%w[
+                                               -o /tmp/Foo.xarchive/dSYMs/Foo.app.dSYM/Contents/Resources/DWARF/Foo
+                                               -l 0x0
+                                               -arch x86_64
+                                             ])
+        end
       end
 
-      let(:launcher) do
-        Tracetool::IOS::IOSTraceScanner.new
-      end
-
-      let(:exec) { double }
-
-      before do
-        atos_args =
-          %w[-o tmp/dSYMs/FooModule.app.dSYM/Contents/Resources/DWARF/FooModule -l 0x0 -arch arm64]
-        expect(Tracetool::Pipe::Executor)
-          .to receive(:new)
-          .with('atos', atos_args)
-          .and_return(exec)
-        allow(exec).to receive(:<<).and_return('foo')
-      end
-
-      it 'runs atos with arguments' do
-        expect(launcher.process('0 FooModule 0x0', ctx))
-          .to eq('0 FooModule foo')
+      describe '#initialize' do
+        %i[load_address xarchive module_name]
+          .each_with_object(load_address: '0x0', xarchive: 'test', module_name: 'Foo') do |argument, object|
+          context "when #{argument} missing" do
+            let(:ctx) { OpenStruct.new(object.dup.update(argument => nil)) }
+            it 'raises exception' do
+              expect { AtosContext.new(ctx) }.to raise_error(ArgumentError)
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
* Moved CLI related logic from `tracetool.rb` to `tracetool_cli`
* `tracetool.rb` is now for requiring stuff all together
* `IOSTraceScanner`, `AndroidTraceScanner` are now having method `#parser` returning 
   appropriate parser instance matching stack trace format
* Test cases refactored to be less verbose. 