### PR TITLE
Fixed false negative match for android native traces with signed addresses

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+# Added 
+
+*  Fixed false negative match for android native stacktraces with signed addresses
+ 
 # Version 0.4.0
 
 * [#1](https://github.com/vizor-games/tracetool/pull/1) Made stack trace parser API usable.

--- a/lib/tracetool/android/native.rb
+++ b/lib/tracetool/android/native.rb
@@ -84,7 +84,7 @@ module Tracetool
       # ** symbol offset `/\d+/`
       #
       # Last two entries can be missing.
-      RX_PACKED_FORMAT = /^(<<<(\d+ [^ ]+ ([^ ]+ \d+)?;)+>>>)+$/
+      RX_PACKED_FORMAT = /^(<<<([-\d]+ [^ ]+ ([^ ]+ \d+)?;)+>>>)+$/
 
       # @param [String] string well formed native android stack trace
       # @see https://developer.android.com/ndk/guides/ndk-stack.html

--- a/spec/tracetool/android/native/scanner_spec.rb
+++ b/spec/tracetool/android/native/scanner_spec.rb
@@ -36,6 +36,11 @@ module Tracetool
               '<<<12345678 foo.so ;12345678 foo.so __bar 42;>>>'
             expect(NativeTraceScanner.packed?(trace)).to be_truthy
           end
+
+          it 'should match trace with signed address' do
+            trace = '<<<12345678 foo.so ;-13080997 foo.so ;12345678 foo.so __bar 42;>>>'
+            expect(NativeTraceScanner.packed?(trace)).to be_truthy
+          end
         end
       end
 


### PR DESCRIPTION
If packed android native trace had negative (signed) stack entry address `NativeTraceScanner` couldn't manage to match such kind of trace. For example: 

```
<<< 123 fo.so;-123 fo.so; >>>
```