### PR TITLE
Feature/find exact file path

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,8 @@
 # Added 
 
-*  Fixed false negative match for android native stacktraces with signed addresses
+* Fixed false negative match for android native stacktraces with signed addresses
+* When parsing unpacked stack trace with multiple source files matched choose files with longest common postfix
+  with original file. 
  
 # Version 0.4.0
 

--- a/lib/tracetool/utils/string.rb
+++ b/lib/tracetool/utils/string.rb
@@ -1,0 +1,24 @@
+module Tracetool
+  # Set of utility methods for working with strings
+  module StringUtils
+    # Extended string class
+    # rubocop:disable Style/ClassAndModuleChildren
+    class ::String
+      # Return longest common postfix
+      # @param [String] other other string to match
+      # @return [String] longest common postfix
+      def longest_common_postfix(other)
+        sidx = length - 1
+        oidx = other.length - 1
+
+        while sidx >= 0 && oidx >= 0 && (self[sidx] == other[oidx])
+          sidx -= 1
+          oidx -= 1
+        end
+
+        other[(oidx + 1)..-1]
+      end
+    end
+    # rubocop:enable Style/ClassAndModuleChildren
+  end
+end

--- a/spec/tracetool/utils/parser_spec.rb
+++ b/spec/tracetool/utils/parser_spec.rb
@@ -39,7 +39,7 @@ describe Tracetool::BaseTraceParser do
     end
 
     context 'when has file list' do
-      let(:files) { %w[com/foo/var.cpp com/bar/jar.cpp com/far/jar.cpp] }
+      let(:files) { %w[com/foo/var.cpp com/bar/jar.cpp com/far/jar.cpp com/test1/foo/jar.cpp com/test2/foo/jar.cpp] }
 
       let(:parser) do
         Tracetool::BaseTraceParser.new(entry_regexp, call_regexp, files)
@@ -53,7 +53,21 @@ describe Tracetool::BaseTraceParser do
       context 'when has ambiguous file name' do
         it 'returns all matching files' do
           expect(parser.parse('A foo.so method jar.cpp:10').first[:call][:file])
-            .to match_array(%w[com/bar/jar.cpp com/far/jar.cpp])
+            .to match_array(%w[com/bar/jar.cpp com/far/jar.cpp com/test1/foo/jar.cpp com/test2/foo/jar.cpp])
+        end
+      end
+
+      context 'when has exact filename among other matching' do
+        it 'returns correct path' do
+          expect(parser.parse('A foo.so method bar/jar.cpp:10').first[:call][:file])
+            .to eq('com/bar/jar.cpp')
+        end
+      end
+
+      context 'when has multiple files with same path postfix' do
+        it 'returns all matching files' do
+          expect(parser.parse('A foo.so method foo/jar.cpp:10').first[:call][:file])
+            .to match_array(%w[com/test1/foo/jar.cpp com/test2/foo/jar.cpp])
         end
       end
     end

--- a/spec/tracetool/utils/string_spec.rb
+++ b/spec/tracetool/utils/string_spec.rb
@@ -1,0 +1,27 @@
+require_relative lib('tracetool/utils/string')
+
+module Tracetool
+  module StringUtils
+    describe String do
+      describe 'longest_common_postfix' do
+        context 'when strings has no common postfix' do
+          it 'returns empty string' do
+            expect('aaa'.longest_common_postfix('bbb')).to eq('')
+          end
+        end
+
+        context 'when other string is a postfix of original string' do
+          it 'returns other string' do
+            expect('xyz-other'.longest_common_postfix('other')).to eq('other')
+          end
+        end
+
+        context 'when original string is a postfix of other string' do
+          it 'returns original string' do
+            expect('original'.longest_common_postfix('xyz-original')).to eq('original')
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When parsing unpacked stack trace with multiple source files matched choose files with longest common postfix with original file.

Use case:

Archive with source files contains following entries

```
sources/com/test/objects/Pool.cpp
sources/com/test/Pool.cpp
```

Resolved stack trace points to `com/test/Pool.cpp`, so `sources/com/test/Pool.cpp` should be resolved in parsed stack trace. 