### PR TITLE
Fixed issue when ambiguous file names were resolved wrongly

### DIFF
--- a/lib/tracetool/android/native.rb
+++ b/lib/tracetool/android/native.rb
@@ -84,7 +84,7 @@ module Tracetool
       # ** symbol offset `/\d+/`
       #
       # Last two entries can be missing.
-      RX_PACKED_FORMAT = /^(<<<([-\d]+ [^ ]+ ([^ ]+ \d+)?;)+>>>)+$/
+      RX_PACKED_FORMAT = /^(<<<([-\d]+ [^ ]+ (.+)?;)+>>>)+$/
 
       # @param [String] string well formed native android stack trace
       # @see https://developer.android.com/ndk/guides/ndk-stack.html

--- a/spec/tracetool/android/native/scanner_spec.rb
+++ b/spec/tracetool/android/native/scanner_spec.rb
@@ -41,6 +41,11 @@ module Tracetool
             trace = '<<<12345678 foo.so ;-13080997 foo.so ;12345678 foo.so __bar 42;>>>'
             expect(NativeTraceScanner.packed?(trace)).to be_truthy
           end
+
+          it do
+            trace = '<<<305256 libc.so tgkill+12;294883 libc.so pthread_kill+34;121773 libc.so raise+10;>>>'
+            expect(NativeTraceScanner.packed?(trace)).to be_truthy
+          end
         end
       end
 
@@ -72,6 +77,25 @@ module Tracetool
             expect(NativeTraceScanner.without_header?(trace)).to be_truthy
           end
         end
+
+        context 'when in trace from google play console' do
+          let(:trace) do
+            <<-TRACE.strip_indent
+            #00  pc 000000000004a868  /system/lib/libc.so (tgkill+12)
+            #01  pc 0000000000047fe3  /system/lib/libc.so (pthread_kill+34)
+            #02  pc 000000000001dbad  /system/lib/libc.so (raise+10)
+            #03  pc 0000000000019321  /system/lib/libc.so (__libc_android_abort+34)
+            #04  pc 0000000000017388  /system/lib/libc.so (abort+4)
+            TRACE
+          end
+
+          it do
+            expect(NativeTraceScanner.without_header?(trace)).to be_truthy
+          end
+        end
+      end
+
+      describe '::without_header?' do
       end
 
       describe '::with_header?' do

--- a/spec/tracetool/utils/parser_spec.rb
+++ b/spec/tracetool/utils/parser_spec.rb
@@ -57,6 +57,14 @@ describe Tracetool::BaseTraceParser do
         end
       end
 
+      context 'when has files with same postfixes' do
+        let(:files) { %w[com/foobar.cpp com/bar.cpp] }
+        it 'returns best matching file' do
+          expect(parser.parse('A foo.so method bar.cpp:10').first[:call][:file])
+            .to eq('com/bar.cpp')
+        end
+      end
+
       context 'when has exact filename among other matching' do
         it 'returns correct path' do
           expect(parser.parse('A foo.so method bar/jar.cpp:10').first[:call][:file])


### PR DESCRIPTION
When having list of files with same andings like

```
Foo.cpp
BarFoo.cpp
```

and call description with 'Foo.cpp' file mentioned. File `BarFoo.cpp'
got resolved wrongly (marked as matching).

Now before lookup for matching files will drop all files which `File.basename`
differs from original file.